### PR TITLE
Refresh page metadata to match current copy

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -26,6 +26,8 @@ export async function generateMetadata(
 
   return {
     title: 'About',
+    description:
+      'How the club started, how it runs, and the founding team behind it. The Good for Nothings Club grew from a weekly accountability meeting into a creators clubhouse in Austin, TX.',
     alternates: {
       canonical: pathname,
     },

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -17,6 +17,8 @@ export async function generateMetadata(
 
   return {
     title: 'Contact',
+    description:
+      'Say hello, ask a question, or start something - email hello@thegoodfornothings.club, find the club on socials, or send a message and come by the clubhouse in Austin, TX.',
     alternates: {
       canonical: pathname,
     },

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata(
   return {
     title: 'Events',
     description:
-      'The club, in session - regular happenings at the clubhouse in Austin, TX. Members and friends of members welcome.',
+      'The club, in session - regular happenings at the clubhouse in Austin, TX, including Works in Progress and the Off Genre Jam. Members, associates, and friends of the club welcome.',
     alternates: {
       canonical: pathname,
     },

--- a/app/facilities/page.tsx
+++ b/app/facilities/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(
   return {
     title: 'Facilities',
     description:
-      'The clubhouse, room by room - permanent desks, band practice, photo studio, and recording control room in Austin, TX. Monthly and hourly rental.',
+      'The clubhouse, room by room - permanent desks, band practice, photo studio, mixing control room, and consignment shop in Austin, TX. Rented by the month or by the hour.',
     alternates: {
       canonical: pathname,
     },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata(): Promise<Metadata> {
       default: 'Creators club from ATX | The Good for Nothings Club',
     },
     description:
-      'The Good for Nothings Club is a creators club in Austin, TX made up of musicians, photographers, writers, filmmakers, and engineers. Our clubhouse puts studios, rehearsal rooms, and workspace under one roof. Good for nothings. Making everything.',
+      'The Good for Nothings Club is a creators club based in Austin, TX made up of musicians, photographers, writers, filmmakers, and engineers. Our clubhouse puts studios, rehearsal rooms, and workspace under one roof. Good for nothings. Making everything.',
     referrer: 'origin-when-cross-origin',
     keywords: [
       'creator',

--- a/app/members/[slug]/page.tsx
+++ b/app/members/[slug]/page.tsx
@@ -33,8 +33,9 @@ export async function generateMetadata(
   })) as unknown as GFNC_member
 
   return {
-    title: `${member.fullName} – Good For Nothings Club`,
-    description: `${member.fullName} is a member of The Good For Nothings Club. ${member.roles.join(', ')}.`,
+    // The layout title template appends "| The Good for Nothings Club".
+    title: member.fullName,
+    description: `${member.fullName} is a member of The Good for Nothings Club. ${member.roles.join(', ')}.`,
     alternates: {
       canonical: pathname,
     },

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -48,6 +48,8 @@ export async function generateMetadata(
 
   return {
     title: 'Projects',
+    description:
+      'Selected work from club members - audio, video, photo, web, builds, and events. Browse what The Good for Nothings Club is making now and what it has shipped.',
     alternates: {
       canonical: pathname,
     },


### PR DESCRIPTION
Audited every page's meta title/description against the visible copy (several pages had copy updates without matching meta updates).

## Fixed
- **Events** — audience wording was stale: now 'members, associates, and friends of the club' and names both recurring series (Works in Progress, Off Genre Jam)
- **Facilities** — 'recording control room' → 'mixing control room', adds the consignment shop
- **About / Contact / Projects** — were silently inheriting the generic homepage description; each now has a page-specific one
- **Member pages** — title no longer double-brands ('Jane Doe – Good For Nothings Club | The Good for Nothings Club' → 'Jane Doe | The Good for Nothings Club') and description casing fixed
- **Layout default** — 'based in Austin, TX' to match the homepage lead

## Already accurate (no change)
Membership, Services, project detail pages (dynamic from content), homepage.

## Test plan
- Rendered `<title>` + `<meta name=description>` verified via curl on all 9 routes against the dev server
- tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)