### PR TITLE
Anchor event RSVPs to specific dates

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,12 +1,17 @@
 import Link from 'next/link'
 import type { Metadata, ResolvingMetadata } from 'next'
 
+import GroupLabel from '@/components/GroupLabel'
 import InquiryDialog from '@/components/InquiryDialog'
 import OfferCard from '@/components/OfferCard'
 import PageShell from '@/components/PageShell'
-import PriceMenu from '@/components/PriceMenu'
 import SectionHeading from '@/components/SectionHeading'
-import { events, eventsCopy, upcomingOccurrences } from '@/data/events'
+import {
+  events,
+  eventsCopy,
+  formatOccurrenceDate,
+  upcomingOccurrences,
+} from '@/data/events'
 
 // Recompute the upcoming schedule daily.
 export const revalidate = 86400
@@ -38,29 +43,68 @@ function occurrenceDate(iso: string) {
 
 export default function Events() {
   const upcoming = upcomingOccurrences(new Date(), 8)
-
-  const calendarLines = upcoming.map(occurrence => {
-    const date = occurrenceDate(occurrence.date)
-    return {
-      group: date.toLocaleDateString('en-US', {
-        month: 'long',
-        timeZone: 'UTC',
-      }),
-      item: `${date.toLocaleDateString('en-US', {
-        weekday: 'short',
-        timeZone: 'UTC',
-      })} ${date.getUTCDate()} · ${occurrence.event.time}`,
-      price: occurrence.event.name,
-    }
-  })
+  const months = [
+    ...new Set(
+      upcoming.map(occurrence =>
+        occurrenceDate(occurrence.date).toLocaleDateString('en-US', {
+          month: 'long',
+          timeZone: 'UTC',
+        })
+      )
+    ),
+  ]
 
   return (
     <PageShell title='Events' lead={`The club, in session. ${eventsCopy.lead}`}>
       <div className='grid grid-cols-1 gap-6 md:gap-16 lg:grid-cols-2'>
         <div>
           <SectionHeading title={eventsCopy.calendarTitle} />
-          <div className='mt-6'>
-            <PriceMenu lines={calendarLines} />
+          {/* Each date carries its own RSVP so it's always clear which
+              occurrence you're signing up for. */}
+          <div className='mt-6 space-y-6 font-sans text-sm'>
+            {months.map(month => (
+              <div key={month}>
+                <GroupLabel>{month}</GroupLabel>
+                {upcoming
+                  .filter(
+                    occurrence =>
+                      occurrenceDate(occurrence.date).toLocaleDateString(
+                        'en-US',
+                        { month: 'long', timeZone: 'UTC' }
+                      ) === month
+                  )
+                  .map(occurrence => {
+                    return (
+                      <div
+                        key={`${occurrence.event.slug}-${occurrence.date}`}
+                        className='flex items-center gap-2 py-1'
+                      >
+                        <span className='whitespace-nowrap'>
+                          {formatOccurrenceDate(occurrence.date)} ·{' '}
+                          {occurrence.event.time}
+                        </span>
+                        <span
+                          aria-hidden
+                          className='min-w-6 flex-1 border-b-2 border-dotted border-black/25'
+                        />
+                        <span className='text-base font-bold'>
+                          {occurrence.event.name}
+                        </span>
+                        <InquiryDialog
+                          kind='event'
+                          item={occurrence.event.name}
+                          occurrenceDate={occurrence.date}
+                          triggerLabel='RSVP'
+                          triggerVariant='outline'
+                          triggerClassName='h-8 px-3 text-xs shrink-0'
+                          title={`RSVP - ${occurrence.event.name}`}
+                          submitLabel='RSVP'
+                        />
+                      </div>
+                    )
+                  })}
+              </div>
+            ))}
           </div>
         </div>
 
@@ -79,9 +123,8 @@ export default function Events() {
                   <InquiryDialog
                     kind='event'
                     item={event.name}
-                    triggerLabel='RSVP'
+                    triggerLabel='RSVP to the next one'
                     title={`RSVP - ${event.name}`}
-                    description={`${event.schedule} at the clubhouse.`}
                     submitLabel='RSVP'
                   />
                 }

--- a/components/InquiryDialog.tsx
+++ b/components/InquiryDialog.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from 'react'
 
-import { events } from '../data/events'
+import { events, formatOccurrenceLong } from '../data/events'
 import type { InquiryKind } from '../data/schemas'
-import InquiryForm from './InquiryForm'
-import { Button } from './ui/Button'
+import InquiryForm, { type InquirySelection } from './InquiryForm'
+import { Button, type ButtonProps } from './ui/Button'
 import {
   Dialog,
   DialogContent,
@@ -18,7 +18,12 @@ import {
 type InquiryDialogProps = {
   kind: InquiryKind
   item: string
+  /** For event RSVPs: preselect this occurrence (YYYY-MM-DD). */
+  occurrenceDate?: string
   triggerLabel: string
+  triggerVariant?: ButtonProps['variant']
+  triggerSize?: ButtonProps['size']
+  triggerClassName?: string
   title: string
   description?: string
   submitLabel?: string
@@ -27,12 +32,20 @@ type InquiryDialogProps = {
 export default function InquiryDialog({
   kind,
   item,
+  occurrenceDate,
   triggerLabel,
+  triggerVariant,
+  triggerSize,
+  triggerClassName,
   title,
   description,
   submitLabel,
 }: InquiryDialogProps) {
-  const [selection, setSelection] = useState({ kind, item })
+  const [selection, setSelection] = useState<InquirySelection>({
+    kind,
+    item,
+    occurrenceDate,
+  })
 
   // Keep the header in sync when the Regarding dropdown changes.
   const displayTitle =
@@ -45,14 +58,23 @@ export default function InquiryDialog({
     selection.kind === 'event'
       ? events.find(event => event.name === selection.item)
       : undefined
-  const displayDescription = selectedEvent
-    ? `${selectedEvent.schedule} at the clubhouse.`
-    : description
+  const displayDescription =
+    selectedEvent && selection.occurrenceDate
+      ? `${formatOccurrenceLong(selection.occurrenceDate, selectedEvent.time)} at the clubhouse.`
+      : selectedEvent
+        ? `${selectedEvent.schedule} at the clubhouse.`
+        : description
 
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button className=''>{triggerLabel}</Button>
+        <Button
+          variant={triggerVariant}
+          size={triggerSize}
+          className={triggerClassName}
+        >
+          {triggerLabel}
+        </Button>
       </DialogTrigger>
       <DialogContent className='max-h-[90vh] overflow-hidden border-2 border-black p-0'>
         <div className='grid max-h-[calc(90vh-4px)] gap-4 overflow-y-auto p-6'>
@@ -67,6 +89,7 @@ export default function InquiryDialog({
           <InquiryForm
             defaultKind={kind}
             defaultItem={item}
+            defaultOccurrenceDate={occurrenceDate}
             submitLabel={submitLabel}
             onSelectionChange={setSelection}
           />

--- a/components/InquiryForm.tsx
+++ b/components/InquiryForm.tsx
@@ -6,7 +6,12 @@ import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
-import { events } from '../data/events'
+import {
+  events,
+  formatOccurrenceDate,
+  formatOccurrenceLong,
+  upcomingOccurrences,
+} from '../data/events'
 import { phoneSchema, type InquiryKind } from '../data/schemas'
 import { services } from '../data/services'
 import { Alert, AlertDescription, AlertTitle } from './ui/Alert'
@@ -35,12 +40,27 @@ const GENERAL_SUBJECTS = [
   'Other',
 ]
 
-/** Encode kind + item into a single select value. */
-const encode = (kind: InquiryKind, item: string) => `${kind}|${item}`
+/**
+ * Encode kind + item into a single select value. Event RSVPs carry a third
+ * segment — the occurrence date (YYYY-MM-DD) — so every RSVP names one
+ * specific date.
+ */
+const encode = (kind: InquiryKind, item: string, occurrenceDate?: string) =>
+  occurrenceDate ? `${kind}|${item}|${occurrenceDate}` : `${kind}|${item}`
 
-function decode(value: string): { kind: InquiryKind; item: string } {
+export type InquirySelection = {
+  kind: InquiryKind
+  item: string
+  /** YYYY-MM-DD; present for event RSVPs. */
+  occurrenceDate?: string
+}
+
+function decode(value: string): InquirySelection {
   if (value === GENERAL) return { kind: 'general', item: 'General Inquiry' }
   const [kind, ...rest] = value.split('|')
+  if (kind === 'event' && rest.length === 2) {
+    return { kind, item: rest[0], occurrenceDate: rest[1] }
+  }
   return { kind: kind as InquiryKind, item: rest.join('|') }
 }
 
@@ -71,24 +91,43 @@ type InquiryFormProps = {
   defaultKind?: InquiryKind
   /** The specific service or event, when launched from its card. */
   defaultItem?: string
+  /** For event RSVPs: the occurrence date (YYYY-MM-DD) being RSVP'd to. */
+  defaultOccurrenceDate?: string
   submitLabel?: string
   /** Fires when the Regarding selection changes, e.g. to retitle a dialog. */
-  onSelectionChange?: (selection: { kind: InquiryKind; item: string }) => void
+  onSelectionChange?: (selection: InquirySelection) => void
 }
 
 export default function InquiryForm({
   defaultKind = 'general',
   defaultItem,
+  defaultOccurrenceDate,
   submitLabel = 'Send',
   onSelectionChange,
 }: InquiryFormProps) {
+  // Every RSVP targets one concrete date. The Regarding menu lists the next
+  // occurrences of all events, so people can also RSVP further out.
+  const occurrences =
+    defaultKind === 'event' ? upcomingOccurrences(new Date(), 8) : []
+
+  const defaultRegarding = () => {
+    if (defaultKind === 'general' || !defaultItem) return GENERAL
+    if (defaultKind === 'event') {
+      const occurrence =
+        occurrences.find(
+          o => o.event.name === defaultItem && o.date === defaultOccurrenceDate
+        ) ?? occurrences.find(o => o.event.name === defaultItem)
+      if (occurrence) {
+        return encode('event', occurrence.event.name, occurrence.date)
+      }
+    }
+    return encode(defaultKind, defaultItem)
+  }
+
   const form = useForm<ContactValues>({
     resolver: zodResolver(contactSchema),
     defaultValues: {
-      regarding:
-        defaultKind === 'general' || !defaultItem
-          ? GENERAL
-          : encode(defaultKind, defaultItem),
+      regarding: defaultRegarding(),
       name: '',
       email: '',
       phone: '',
@@ -111,20 +150,32 @@ export default function InquiryForm({
       {service.name}
     </option>
   ))
-  const eventOptions = events.map(event => (
-    <option key={event.slug} value={encode('event', event.name)}>
-      RSVP: {event.name}
+  const eventOptions = occurrences.map(occurrence => (
+    <option
+      key={`${occurrence.event.slug}-${occurrence.date}`}
+      value={encode('event', occurrence.event.name, occurrence.date)}
+    >
+      {occurrence.event.name} — {formatOccurrenceDate(occurrence.date)} ·{' '}
+      {occurrence.event.time}
     </option>
   ))
 
   async function onSubmit(values: ContactValues) {
-    const { kind, item } = decode(values.regarding)
+    const { kind, item, occurrenceDate } = decode(values.regarding)
+    const event = occurrenceDate
+      ? events.find(e => e.name === item)
+      : undefined
     const response = await fetch('/api/inquiry', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         kind,
         item,
+        // The specific date being RSVP'd to, e.g. "Thu, Aug 13, 2026 · 4 PM".
+        offering:
+          occurrenceDate && event
+            ? formatOccurrenceLong(occurrenceDate, event.time)
+            : undefined,
         name: values.name,
         email: values.email,
         phone: values.phone || undefined,

--- a/data/events.ts
+++ b/data/events.ts
@@ -64,6 +64,28 @@ function isoDay(date: Date) {
   return date.toISOString().slice(0, 10)
 }
 
+/** "Thu, Aug 13" for a YYYY-MM-DD occurrence date. */
+export function formatOccurrenceDate(iso: string) {
+  return new Date(`${iso}T12:00:00Z`).toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+/** "Thu, Aug 13, 2026 · 4 PM" — the full RSVP subject for one occurrence. */
+export function formatOccurrenceLong(iso: string, time: string) {
+  const date = new Date(`${iso}T12:00:00Z`).toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  })
+  return `${date} · ${time}`
+}
+
 function matchesRule(date: Date, rule: EventRule) {
   if (date.getUTCDay() !== rule.weekday) return false
   if (rule.freq === 'weekly') return true


### PR DESCRIPTION
## Summary
- Every calendar occurrence gets its own RSVP button; the dialog opens preselected to that exact date and shows it in the header ("Thu, Oct 8, 2026 · 4 PM at the clubhouse.")
- The Regarding menu lists the next 8 occurrences across all events, so people can RSVP to any future date and switch dates inside the dialog (header updates live)
- Submissions carry `offering` = the full date string, which the notification email and admin inquiries page already display
- Recurring cards' button is now "RSVP to the next one" and preselects that event's next occurrence
- Calendar rows use the same "Sun, Jul 19 · 7 PM" format as the dialog dropdown

## Test plan
- Browser-verified: per-date preselection, date switching with live header sync, recurring-card next-occurrence preselection, and the submitted payload (fetch intercepted client-side: `offering: "Sun, Aug 16, 2026 · 7 PM"`)
- tsc + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)