### PR TITLE
Fix Instagram feed videos hijacking fullscreen on iOS

### DIFF
--- a/components/InstagramFeed.tsx
+++ b/components/InstagramFeed.tsx
@@ -70,6 +70,9 @@ export default function InstagramFeed({ feedId }: { feedId: string }) {
           muted={true}
           autoPlay={true}
           loop={true}
+          // Without playsInline, iOS Safari throws autoplaying videos into
+          // the native fullscreen player.
+          playsInline={true}
           className='h-full w-full object-cover'
         />
       )


### PR DESCRIPTION
iOS Safari throws autoplaying videos into the native fullscreen player unless they have `playsinline` — the Instagram feed's `<video muted autoPlay loop>` was missing it, so the first video took over the screen while scrolling the homepage on iPhone.

One-attribute fix; verified both feed videos render with `playsinline` in the DOM. Tapping a video still opens the Instagram post as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)