### PR TITLE
Open remaining external links in a new tab

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -102,6 +102,8 @@ export default async function About() {
             <li>
               <Link
                 href='https://shop.thegoodfornothings.club/'
+                target='_blank'
+                rel='noopener noreferrer'
                 className='font-bold'
               >
                 The shop

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -62,11 +62,15 @@ export default function Home() {
               href: 'https://shop.thegoodfornothings.club/',
               title: 'Shop',
               body: 'Works and merch from members and friends of the club.',
+              external: true,
             },
           ].map(card => (
             <Link
               key={card.href}
               href={card.href}
+              {...(card.external
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
               className='group flex flex-col justify-between gap-2 border-black p-6 transition-colors not-first:border-t-2 hover:bg-black/10 hover:no-underline active:bg-black/20 md:flex-row md:items-center md:gap-8 md:px-12 md:py-10'
             >
               <span className='flex items-center gap-0.5 font-sans text-[32px] font-black tracking-[-0.04em] uppercase md:text-[40px]'>

--- a/components/InstagramFeed.tsx
+++ b/components/InstagramFeed.tsx
@@ -109,6 +109,8 @@ export default function InstagramFeed({ feedId }: { feedId: string }) {
         <div className='flex flex-col items-start justify-center gap-1'>
           <a
             href={`https://www.instagram.com/${feed.username}`}
+            target='_blank'
+            rel='noopener noreferrer'
             className='font-bold'
           >
             @{feed.username}

--- a/components/SocialMediaLinks.tsx
+++ b/components/SocialMediaLinks.tsx
@@ -43,6 +43,7 @@ export default function SocialMediaLinks() {
           key={href}
           href={href}
           target='_blank'
+          rel='noopener noreferrer'
           aria-label={label}
           className='transition-transform duration-200 ease-out hover:-translate-y-1 hover:scale-125 active:translate-y-0 active:scale-95 odd:hover:-rotate-12 even:hover:rotate-12'
         >


### PR DESCRIPTION
## Summary

Follow-up to 28f3b6c, which made the header nav, mobile menu, and footer **Shop** links open in a new tab. This audits every external link on the site and fixes the four that didn't match that convention.

All external links now open in a new tab with `rel="noopener noreferrer"`; internal navigation stays in-tab.

## Changes

| Link | File | Was | Now |
|------|------|-----|-----|
| Shop card in homepage offering grid | `app/page.tsx` | plain `<Link>`, no new tab | opens new tab |
| "The shop" body link | `app/about/page.tsx` | no `target`/`rel` | opens new tab |
| Instagram `@username` profile link | `components/InstagramFeed.tsx` | no `target`/`rel` | opens new tab |
| Social media icon links | `components/SocialMediaLinks.tsx` | `target="_blank"`, no `rel` | added `rel="noopener noreferrer"` |

Left unchanged: internal route links, `sitemap.ts` metadata URLs, and admin tooling links (already correct).

## Verification

Ran the dev server and confirmed via the DOM that every external link on the home and about pages resolves to `target="_blank"` + `rel="noopener noreferrer"`, and internal links do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)